### PR TITLE
Stop firefox from whining about <meta charset=...

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -1,4 +1,4 @@
-<!-- inject:win-logo-ascii --><!-- endinject --><!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
     <head>
 		<meta charset="utf-8">
@@ -20,6 +20,7 @@
 		<script type="text/javascript" src="../js/collab-vm/collab-vm.js"></script>
 		<!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/holder/2.9.1/holder.min.js"></script>-->
 		<!-- endinject -->
+	   	<!-- inject:win-logo-ascii --><!-- endinject -->
     </head>
     <body>
 		<!-- inject:navbar -->


### PR DESCRIPTION
Currently firefox whines about \<meta charset=... not being within the first 1024 bytes of index.html, due to the ASCII art being at the very start of the document. I moved it to the end of \<head\> to solve this.